### PR TITLE
Chore: Add a default estimated usage file for cost estimates

### DIFF
--- a/estimated-usage.yml
+++ b/estimated-usage.yml
@@ -1,0 +1,73 @@
+# You can use this file to define resource usage estimates for Infracost to use when calculating
+# the cost of usage-based resource, such as AWS S3 or Lambda.
+# `infracost breakdown --usage-file infracost-usage.yml [other flags]`
+# See https://infracost.io/usage-file/ for docs
+version: 0.1
+resource_type_default_usage:
+  ##
+  ## The following usage values apply to each resource of the given type, which is useful when you want to define defaults.
+  ## All values are commented-out, you can uncomment resource types and customize as needed.
+  ##
+  ibm_resource_instance:
+    appconnect_gigabyte_transmitted_outbounds: 1
+    appconnect_thousand_runs: 1
+    appconnect_vcpu_hours: 730
+    appid_advanced_authentications: 20000
+    appid_authentications: 15000
+    appid_users: 1000
+    kms_key_versions: 6
+    secretsmanager_active_secrets: 1
+    secretsmanager_instance: 1
+    logdna_gigabyte_months: 1
+    activitytracker_gigabyte_months: 1
+    monitoring_node_hour: 700.0
+    monitoring_container_hour: 700.0
+    monitoring_api_call: 1000
+    monitoring_timeseries_hour: 101000
+    continuousdelivery_authorized_users: 1
+    wml_capacity_unit_hour: 20
+    wml_instance: 1
+    wml_class1_ru: 20
+    wml_class2_ru: 20
+    wml_class3_ru: 20
+    wa_instance: 1
+    wa_monthly_active_users: 1001
+    wa_monthly_voice_users: 1
+    wd_instance: 1
+    wd_documents: 11000
+    wd_queries: 11000
+    wd_custom_models: 4
+    wd_collections: 301
+    scc_evaluations: 1
+    data-science-experience_CAPACITY_UNIT_HOURS: 1.0
+    sysdig-secure_MULTI_CLOUD_CSPM_COMPUTE_INSTANCES: 0.0
+    sysdig-secure_NODE_HOURS: 0.0
+    sysdig-secure_VM_NODE_HOUR: 501
+    aiopenscale_RESOURCE_UNITS: 1.0
+    aiopenscale_MODELS_PER_MONTH: 1.0
+resource_usage:
+  ##
+  ## The following usage values apply to individual resources and override any value defined in the resource_type_default_usage section.
+  ## All values are commented-out, you can uncomment resources and customize as needed.
+  ##
+  ibm_resource_instance.assistant_instance[0]:
+    wa_instance: 1
+    wa_monthly_active_users: 100
+    wa_monthly_voice_users: 0
+  ibm_resource_instance.discovery_instance[0]:
+    wd_instance: 1
+    wd_documents: 10000
+    wd_queries: 1
+    wd_custom_models: 1
+    wd_collections: 1
+  ibm_resource_instance.governance_instance[0]:
+    aiopenscale_RESOURCE_UNITS: 1
+    aiopenscale_MODELS_PER_MONTH: 1
+  ibm_resource_instance.machine_learning_instance:
+    wml_capacity_unit_hour: 0
+    wml_instance: 1
+    wml_class1_ru: 0
+    wml_class2_ru: 0
+    wml_class3_ru: 166000
+  ibm_resource_instance.studio_instance:
+    data-science-experience_CAPACITY_UNIT_HOURS: 30


### PR DESCRIPTION
### Description

Adding an estimated-usage.yml file to the DA to override the default quantities used when generating cost estimates. This will result in a more accurate cost estimate.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Where ever a cost estimate is shown when using the DA, the estimated usage quantities specified in the file will be used.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
