### PR TITLE
feat:exposed visibility value for the provider in the DA

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ statement instead the previous block.
 | <a name="input_existing_studio_instance"></a> [existing\_studio\_instance](#input\_existing\_studio\_instance) | CRN of the an existing Watson Studio instance. | `string` | `null` | no |
 | <a name="input_ibmcloud_api_key"></a> [ibmcloud\_api\_key](#input\_ibmcloud\_api\_key) | The API key that's used with the IBM Cloud Terraform IBM provider. | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | The location that's used with the IBM Cloud Terraform IBM provider. It's also used during resource creation. | `string` | `"us-south"` | no |
+| <a name="input_provider_visibility"></a> [provider\_visibility](#input\_provider\_visibility) | Set the visibility value for the IBM terraform provider. Supported values are `public`, `private`, `public-and-private`. [Learn more](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/guides/custom-service-endpoints). | `string` | `"private"` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of a new or an existing resource group where the resources are created. | `string` | n/a | yes |
 | <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | The name to be used on all Watson resources as a prefix. | `string` | `"watsonx-poc"` | no |
 | <a name="input_use_existing_resource_group"></a> [use\_existing\_resource\_group](#input\_use\_existing\_resource\_group) | Determines whether to use an existing resource group. | `bool` | `false` | no |

--- a/cra-config.yaml
+++ b/cra-config.yaml
@@ -8,3 +8,4 @@ CRA_TARGETS:
       TF_VAR_watsonx_admin_api_key: "fake_value"
       TF_VAR_resource_group_name: "test"
       TF_VAR_cos_kms_crn: "crn:v1:bluemix:public:kms:us-south:a/abac0df06b644a9cabc6e44f55b3880e:a20230fb-9ec3-4376-a27d-8ca21a94728a::"
+      TF_VAR_provider_visibility: "public"

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -73,6 +73,23 @@
               "type": "password"
             },
             {
+              "key": "provider_visibility",
+              "options": [
+                {
+                  "displayname": "private",
+                  "value": "private"
+                },
+                {
+                  "displayname": "public",
+                  "value": "public"
+                },
+                {
+                  "displayname": "public-and-private",
+                  "value": "public-and-private"
+                }
+              ]
+            },
+            {
               "key": "location",
               "type": "string",
               "default_value": "us-south",

--- a/providers.tf
+++ b/providers.tf
@@ -2,12 +2,14 @@ provider "ibm" {
   alias            = "deployer"
   ibmcloud_api_key = var.ibmcloud_api_key
   region           = var.location
+  visibility       = var.provider_visibility
 }
 
 provider "ibm" {
   alias            = "watsonx_admin"
   ibmcloud_api_key = var.watsonx_admin_api_key == null || var.watsonx_admin_api_key == "" ? var.ibmcloud_api_key : var.watsonx_admin_api_key
   region           = var.location
+  visibility       = var.provider_visibility
 }
 
 

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -66,6 +66,7 @@ func setupOptionsRootDA(t *testing.T, prefix string, dir string) *testhelper.Tes
 			"location":                  validRegions[rand.Intn(len(validRegions))],
 			"resource_group_name":       prefix,
 			"enable_cos_kms_encryption": false,
+			"provider_visibility":     "public",
 		},
 	})
 
@@ -153,6 +154,7 @@ func TestWithExistingKP(t *testing.T) {
 			TerraformVars: map[string]interface{}{
 				"location":            validRegions[rand.Intn(len(validRegions))],
 				"resource_group_name": prefix,
+				"provider_visibility":     "public",
 				"cos_kms_crn":         terraform.Output(t, existingTerraformOptions, "key_protect_crn"),
 				"cos_kms_key_crn":     terraform.Output(t, existingTerraformOptions, "kms_key_crn"),
 			},

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -66,7 +66,7 @@ func setupOptionsRootDA(t *testing.T, prefix string, dir string) *testhelper.Tes
 			"location":                  validRegions[rand.Intn(len(validRegions))],
 			"resource_group_name":       prefix,
 			"enable_cos_kms_encryption": false,
-			"provider_visibility":     "public",
+			"provider_visibility":       "public",
 		},
 	})
 
@@ -154,7 +154,7 @@ func TestWithExistingKP(t *testing.T) {
 			TerraformVars: map[string]interface{}{
 				"location":            validRegions[rand.Intn(len(validRegions))],
 				"resource_group_name": prefix,
-				"provider_visibility":     "public",
+				"provider_visibility": "public",
 				"cos_kms_crn":         terraform.Output(t, existingTerraformOptions, "key_protect_crn"),
 				"cos_kms_key_crn":     terraform.Output(t, existingTerraformOptions, "kms_key_crn"),
 			},

--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,16 @@ variable "ibmcloud_api_key" {
   sensitive   = true
   type        = string
 }
+variable "provider_visibility" {
+  description = "Set the visibility value for the IBM terraform provider. Supported values are `public`, `private`, `public-and-private`. [Learn more](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/guides/custom-service-endpoints)."
+  type        = string
+  default     = "private"
 
+  validation {
+    condition     = contains(["public", "private", "public-and-private"], var.provider_visibility)
+    error_message = "Invalid visibility option. Allowed values are 'public', 'private', or 'public-and-private'."
+  }
+}
 variable "watsonx_admin_api_key" {
   default     = null
   description = "The API key of the IBM watsonx administrator in the target account. The API key is used to configure the user and the project."


### PR DESCRIPTION
### Description

exposed [visibility](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs#visibility) value for the provider in the DA , with default value set to "private"

[Git issue](https://github.ibm.com/GoldenEye/issues/issues/11338)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

exposes visibility value for the provider in the DA

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
