### PR TITLE
feat:scoping exact key

### DIFF
--- a/cra-config.yaml
+++ b/cra-config.yaml
@@ -8,5 +8,4 @@ CRA_TARGETS:
       TF_VAR_watsonx_admin_api_key: "fake_value"
       TF_VAR_resource_group_name: "test"
       TF_VAR_cos_kms_crn: "crn:v1:bluemix:public:kms:us-south:a/abac0df06b644a9cabc6e44f55b3880e:a20230fb-9ec3-4376-a27d-8ca21a94728a::"
-      TF_VAR_cos_kms_key_crn: "crn:v1:bluemix:public:kms:us-south:a/9f9af00a96104f49b6509aa715f9d6a5:44f9c10d-99f5-4547-9e9f-2a1c84b5f0a4:key:f6c9f6d0-92f6-437a-b97c-4b617cb3d320"
       TF_VAR_provider_visibility: "public"

--- a/cra-config.yaml
+++ b/cra-config.yaml
@@ -8,4 +8,5 @@ CRA_TARGETS:
       TF_VAR_watsonx_admin_api_key: "fake_value"
       TF_VAR_resource_group_name: "test"
       TF_VAR_cos_kms_crn: "crn:v1:bluemix:public:kms:us-south:a/abac0df06b644a9cabc6e44f55b3880e:a20230fb-9ec3-4376-a27d-8ca21a94728a::"
+      TF_VAR_cos_kms_key_crn: "crn:v1:bluemix:public:kms:us-south:a/9f9af00a96104f49b6509aa715f9d6a5:44f9c10d-99f5-4547-9e9f-2a1c84b5f0a4:key:f6c9f6d0-92f6-437a-b97c-4b617cb3d320"
       TF_VAR_provider_visibility: "public"

--- a/storage_delegation/main.tf
+++ b/storage_delegation/main.tf
@@ -1,4 +1,4 @@
-module "crn_parser_kms_key" {
+module "kms_key_crn_parser" {
   source  = "terraform-ibm-modules/common-utilities/ibm//modules/crn-parser"
   version = "1.1.0"
   crn     = data.ibm_kms_key.kms_key.keys[0].crn
@@ -14,10 +14,10 @@ locals {
     "jp-tok"   = "jp-tok.dataplatform.cloud.ibm.com"
   }
   dataplatform_ui             = local.dataplatform_ui_mapping[local.location]
-  kms_service                 = module.crn_parser_kms_key.service_name
-  kms_account_id              = module.crn_parser_kms_key.account_id
-  kms_key_id                  = module.crn_parser_kms_key.resource
-  target_resource_instance_id = module.crn_parser_kms_key.service_instance
+  kms_service                 = module.kms_key_crn_parser.service_name
+  kms_account_id              = module.kms_key_crn_parser.account_id
+  kms_key_id                  = module.kms_key_crn_parser.resource
+  target_resource_instance_id = module.kms_key_crn_parser.service_instance
 }
 
 resource "ibm_iam_authorization_policy" "cos_s2s_keyprotect" {

--- a/storage_delegation/main.tf
+++ b/storage_delegation/main.tf
@@ -1,7 +1,14 @@
-module "crn_parser" {
+module "crn_parser_kms_key" {
+  source     = "terraform-ibm-modules/common-utilities/ibm//modules/crn-parser"
+  version    = "1.1.0"
+  crn        = coalesce(var.cos_kms_key_crn, data.ibm_kms_key.kms_key.keys[0].crn)
+  depends_on = [data.ibm_kms_key.kms_key]
+}
+
+module "crn_parser_kms_instance" {
   source  = "terraform-ibm-modules/common-utilities/ibm//modules/crn-parser"
   version = "1.1.0"
-  crn     = var.cos_kms_key_crn
+  crn     = var.cos_kms_crn
 }
 
 locals {
@@ -13,10 +20,10 @@ locals {
     "jp-tok"   = "jp-tok.dataplatform.cloud.ibm.com"
   }
   dataplatform_ui             = local.dataplatform_ui_mapping[local.location]
-  kms_service                 = module.crn_parser.service_name
-  kms_account_id              = module.crn_parser.account_id
-  kms_key_id                  = module.crn_parser.resource
-  target_resource_instance_id = split(":", var.cos_kms_crn)[7]
+  kms_service                 = module.crn_parser_kms_key.service_name
+  kms_account_id              = module.crn_parser_kms_key.account_id
+  kms_key_id                  = module.crn_parser_kms_key.resource
+  target_resource_instance_id = module.crn_parser_kms_instance.service_instance
 }
 
 resource "ibm_iam_authorization_policy" "cos_s2s_keyprotect" {

--- a/storage_delegation/main.tf
+++ b/storage_delegation/main.tf
@@ -1,7 +1,7 @@
 module "crn_parser_kms_key" {
-  source     = "terraform-ibm-modules/common-utilities/ibm//modules/crn-parser"
-  version    = "1.1.0"
-  crn        = data.ibm_kms_key.kms_key.keys[0].crn
+  source  = "terraform-ibm-modules/common-utilities/ibm//modules/crn-parser"
+  version = "1.1.0"
+  crn     = data.ibm_kms_key.kms_key.keys[0].crn
 }
 
 module "crn_parser_kms_instance" {

--- a/storage_delegation/main.tf
+++ b/storage_delegation/main.tf
@@ -1,3 +1,9 @@
+module "crn_parser" {
+  source  = "terraform-ibm-modules/common-utilities/ibm//modules/crn-parser"
+  version = "1.1.0"
+  crn     = var.cos_kms_key_crn
+}
+
 locals {
   location = split(":", var.cos_kms_crn)[5]
   dataplatform_ui_mapping = {
@@ -7,11 +13,9 @@ locals {
     "jp-tok"   = "jp-tok.dataplatform.cloud.ibm.com"
   }
   dataplatform_ui             = local.dataplatform_ui_mapping[local.location]
-  parsed_kms_key_crn          = var.cos_kms_key_crn != null ? split(":", var.cos_kms_key_crn) : []
-  kms_service                 = length(local.parsed_kms_key_crn) > 0 ? local.parsed_kms_key_crn[4] : null
-  kms_scope                   = length(local.parsed_kms_key_crn) > 0 ? local.parsed_kms_key_crn[6] : null
-  kms_account_id              = length(local.parsed_kms_key_crn) > 0 ? split("/", local.kms_scope)[1] : null
-  kms_key_id                  = length(local.parsed_kms_key_crn) > 0 ? local.parsed_kms_key_crn[9] : null
+  kms_service                 = module.crn_parser.service_name
+  kms_account_id              = module.crn_parser.account_id
+  kms_key_id                  = module.crn_parser.resource
   target_resource_instance_id = split(":", var.cos_kms_crn)[7]
 }
 

--- a/storage_delegation/main.tf
+++ b/storage_delegation/main.tf
@@ -13,7 +13,6 @@ locals {
     "eu-de"    = "eu-de.dataplatform.cloud.ibm.com",
     "jp-tok"   = "jp-tok.dataplatform.cloud.ibm.com"
   }
-  create_access_policy_kms    = !var.skip_iam_authorization_policy
   dataplatform_ui             = local.dataplatform_ui_mapping[local.location]
   kms_service                 = module.crn_parser_kms_key.service_name
   kms_account_id              = module.crn_parser_kms_key.account_id
@@ -22,7 +21,7 @@ locals {
 }
 
 resource "ibm_iam_authorization_policy" "cos_s2s_keyprotect" {
-  count                       = local.create_access_policy_kms ? 1 : 0
+  count                       = !var.skip_iam_authorization_policy ? 1 : 0
   provider                    = ibm.deployer
   source_service_name         = "cloud-object-storage"
   source_resource_instance_id = var.cos_guid

--- a/storage_delegation/main.tf
+++ b/storage_delegation/main.tf
@@ -1,8 +1,7 @@
 module "crn_parser_kms_key" {
   source     = "terraform-ibm-modules/common-utilities/ibm//modules/crn-parser"
   version    = "1.1.0"
-  crn        = coalesce(var.cos_kms_key_crn, data.ibm_kms_key.kms_key.keys[0].crn)
-  depends_on = [data.ibm_kms_key.kms_key]
+  crn        = data.ibm_kms_key.kms_key.keys[0].crn
 }
 
 module "crn_parser_kms_instance" {

--- a/storage_delegation/variables.tf
+++ b/storage_delegation/variables.tf
@@ -40,3 +40,9 @@ variable "cos_kms_ring_id" {
   type        = string
   default     = null
 }
+
+variable "skip_iam_authorization_policy" {
+  type        = bool
+  description = "Whether to create an IAM authorization policy that permits the Object Storage instance to read the encryption key from the KMS instance. An authorization policy must exist before an encrypted bucket can be created. Set to `true` to avoid creating the policy. If set to `false`, specify a value for the KMS instance in `existing_kms_guid`."
+  default     = false
+}

--- a/storage_delegation/variables.tf
+++ b/storage_delegation/variables.tf
@@ -43,6 +43,6 @@ variable "cos_kms_ring_id" {
 
 variable "skip_iam_authorization_policy" {
   type        = bool
-  description = "Whether to create an IAM authorization policy that permits the Object Storage instance to read the encryption key from the KMS instance. An authorization policy must exist before an encrypted bucket can be created. Set to `true` to avoid creating the policy. If set to `false`, specify a value for the KMS instance in `existing_kms_guid`."
+  description = "Whether to create an IAM authorization policy that permits the Object Storage instance to read the encryption key from the KMS instance. An authorization policy must exist before an encrypted bucket can be created. Set to `true` to avoid creating the policy. If set to `false`, specify a value for the KMS instance crn in `cos_kms_crn`."
   default     = false
 }


### PR DESCRIPTION
### Description

This PR is to update the KMS auth policy so its scope to the exact KMS key.

[Git issue](https://github.com/terraform-ibm-modules/terraform-ibm-watsonx-saas-da/issues/205)
### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Update the scope of the KMS auth policy to the exact KMS key.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
