### PR TITLE
Added service dropdown picker with null support to the platform_resource widget

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -222,10 +222,6 @@
             },
             {
               "key": "existing_machine_learning_instance",
-              "type": "string",
-              "default_value": "__NULL__",
-              "description": "The CRN of an existing WatsonX SaaS machine learning instance to use in this solution. If not set, a new machine learning instance is provisioned depending on which plan is selected.",
-              "required": false,
               "custom_config": {
                 "type": "platform_resource",
                 "grouping": "deployment",
@@ -255,10 +251,6 @@
             },
             {
               "key": "existing_studio_instance",
-              "type": "string",
-              "default_value": "__NULL__",
-              "description": "The CRN of an existing WatsonX SaaS studio instance to use in this solution. If not set, a new studio instance is provisioned depending on which plan is selected.",
-              "required": false,
               "custom_config": {
                 "type": "platform_resource",
                 "grouping": "deployment",
@@ -310,10 +302,6 @@
             },
             {
               "key": "existing_discovery_instance",
-              "type": "string",
-              "default_value": "__NULL__",
-              "description": "The CRN of an existing WatsonX SaaS discovery instance to use in this solution. If not set, a new discovery instance is provisioned depending on which plan is selected.",
-              "required": false,
               "custom_config": {
                 "type": "platform_resource",
                 "grouping": "deployment",
@@ -370,10 +358,6 @@
             },
             {
               "key": "existing_assistant_instance",
-              "type": "string",
-              "default_value": "__NULL__",
-              "description": "The CRN of an existing WatsonX SaaS assistant instance to use in this solution. If not set, a new assistant instance is provisioned depending on which plan is selected.",
-              "required": false,
               "custom_config": {
                 "type": "platform_resource",
                 "grouping": "deployment",
@@ -408,10 +392,6 @@
             },
             {
               "key": "existing_governance_instance",
-              "type": "string",
-              "default_value": "__NULL__",
-              "description": "The CRN of an existing WatsonX SaaS governance instance to use in this solution. If not set, a new governance instance is provisioned depending on which plan is selected.",
-              "required": false,
               "custom_config": {
                 "type": "platform_resource",
                 "grouping": "deployment",
@@ -446,10 +426,6 @@
             },
             {
               "key": "existing_data_instance",
-              "type": "string",
-              "default_value": "__NULL__",
-              "description": "The CRN of an existing WatsonX SaaS data instance to use in this solution. If not set, a new data instance is provisioned depending on which plan is selected.",
-              "required": false,
               "custom_config": {
                 "type": "platform_resource",
                 "grouping": "deployment",
@@ -489,10 +465,6 @@
             },
             {
               "key": "existing_orchestrate_instance",
-              "type": "string",
-              "default_value": "__NULL__",
-              "description": "The CRN of an existing WatsonX SaaS orchestrate instance to use in this solution. If not set, a new orchestrate instance is provisioned depending on which plan is selected.",
-              "required": false,
               "custom_config": {
                 "type": "platform_resource",
                 "grouping": "deployment",


### PR DESCRIPTION
### Description

Enhanced the platform_resource widget to support service dropdowns picker.

issue: https://github.ibm.com/GoldenEye/issues/issues/16407


- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

- Added support for service dropdown picker in the platform_resource widget.
- The dropdown also includes a null option, allowing users to choose null.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
