### PR TITLE
fix: disable debug mode in restapi provider to prevent secret exposure

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -17,7 +17,7 @@ provider "restapi" {
   alias                = "restapi_watsonx_admin"
   uri                  = "https:"
   write_returns_object = true
-  debug                = true
+  debug                = false
   headers = {
     Authorization = data.ibm_iam_auth_token.restapi.iam_access_token
     Content-Type  = "application/json"


### PR DESCRIPTION
### Description

Fixes issue where the `storage_delegation` and `configure_project` modules were printing secret values in plain text during Terraform operations in Schematics.

The root cause was `debug = true` being set in the restapi provider configuration, which caused all HTTP requests and responses (including sensitive data like CRNs, GUIDs, and API payloads) to be logged.

This PR disables debug mode by setting `debug = false`.

**Note:** For additional protection in Schematics, it's recommended to also set the environment variable `API_DATA_IS_SENSITIVE=true` in the workspace settings, which tells the restapi provider to treat all API data as sensitive.

Closes #17020

### Release required?

- [ ] No release
- [x] Patch release (`x.x.X`)

##### Release notes content

Disabled debug mode in the restapi provider to prevent sensitive data (CRNs, GUIDs, API payloads) from being exposed in plain text during Terraform operations.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [x] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.