### PR TITLE
fix internal links blocking cloud doc builds

### DIFF
--- a/reference-architectures/watsonx-saas-da.md
+++ b/reference-architectures/watsonx-saas-da.md
@@ -29,16 +29,10 @@ related_links:
     url: 'https://cloud.ibm.com/docs/watsonx-ai-saas-automation?topic=watsonx-ai-saas-automation-overview'
     description: 'Description.'
 
-# use-case from 'code' column in
-# https://github.ibm.com/digital/taxonomy/blob/main/topics/topics_flat_list.csv
 use-case: AIAndML
 
-# industry from 'code' column in
-# https://github.ibm.com/digital/taxonomy/blob/main/industries/industries_flat_list.csv
 industry: Banking,FinancialSector,ITConsulting,Technology,Telecommunications
 
-# compliance from 'code' column in
-# https://github.ibm.com/digital/taxonomy/blob/main/compliance_entities/compliance_entities_flat_list.csv
 compliance:
 
 content-type: reference-architecture


### PR DESCRIPTION
### Description

Any internal server links such as test.cloud.ibm.com or github.ibm.com links in the reference architecture MD file are blocking the cloud doc builds for all deployable architectures. Please merge as soon as possible.

